### PR TITLE
Fix TypeError: tuple indices must be integers or slices, not str

### DIFF
--- a/avatar/avatar_display.py
+++ b/avatar/avatar_display.py
@@ -843,12 +843,12 @@ class GooseAvatar(QWidget):
             
         # Process message queue
         if self.is_processing_queue:
-            self.message_queue.append((message, duration, state, action_data))
+            self.queue_message_for_display(message, duration, state, action_data)
             return
             
         # If there's a current message, queue this one
         if self.is_showing_message:
-            self.message_queue.append((message, duration, state, action_data))
+            self.queue_message_for_display(message, duration, state, action_data)
             return
         
         # Suppress all messages except onboarding if onboarding is in progress


### PR DESCRIPTION
Simple fix for the avatar message queue bug introduced in commit 8acd4c4.

Problem: The pause/sleep feature added early return paths that used:
  `self.message_queue.append((message, duration, state, action_data))  # tuple`
But the existing queue processing expected dictionary format from:
  `self.queue_message_for_display()  # creates dict`

Solution: Use the existing proper method instead of direct tuple appending.

This fixes the crash when clicking avatar menu items like 'Enter Prompt'.