### PR TITLE
fix: ensure all adapted recipes include required fields in validation

### DIFF
--- a/adapt-recipes.yaml
+++ b/adapt-recipes.yaml
@@ -55,6 +55,7 @@ prompt: |
       checking your changes work by running the recipe
       looking at how parts of the receipe may be able to be extracted into ~/.local/share/goose-perception/scripts/RECIPE_NAME.sh. The recipe can then specify (in english) that it can try to invoke that script. 
       considering adaptations that may be more relevant to the user 
+      ensuring all recipes include required fields (title, description) based on recipe_spec.md
 
     Once done - appen a short note to ACTIVITY-LOG.md about what you did, and why, and what you hope to achieve
 

--- a/observers/run-observations.sh
+++ b/observers/run-observations.sh
@@ -75,9 +75,11 @@ run_recipe_if_needed() {
   
   if [ -f "$adapted_recipe_path" ]; then
     echo "$(date): Found adapted recipe: $adapted_recipe_path"
-    # Naive validation for required fields
-    if grep -q "title:" "$adapted_recipe_path" && grep -q "description:" "$adapted_recipe_path"; then
+    # Validate the adapted recipe. If valid, use it.
+    if goose recipe validate "$adapted_recipe_path" > /dev/null 2>&1; then
       recipe_to_run="$adapted_recipe_path"
+    else
+      echo "$(date): Adapted recipe $adapted_recipe_path is invalid. Sticking with original recipe"
     fi
   fi
   

--- a/observers/run-observations.sh
+++ b/observers/run-observations.sh
@@ -75,7 +75,10 @@ run_recipe_if_needed() {
   
   if [ -f "$adapted_recipe_path" ]; then
     echo "$(date): Found adapted recipe: $adapted_recipe_path"
-    recipe_to_run="$adapted_recipe_path"
+    # Naive validation for required fields
+    if grep -q "title:" "$adapted_recipe_path" && grep -q "description:" "$adapted_recipe_path"; then
+      recipe_to_run="$adapted_recipe_path"
+    fi
   fi
   
   # Check if weekday_only is enabled and today is weekend


### PR DESCRIPTION
- Goose has been replacing `title` with `name` when "adapting" the yaml files, causing recipes to fail.

![image](https://github.com/user-attachments/assets/8a6bad8a-7f20-4b5c-95fb-a12630fbb686)
