### PR TITLE
feature: Add chrome history observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is the most personal way to build up a background assistant that can take a
 ## Quick start 
 
 Run this via `just run` and let it observe how you work (watch and listen), in the background it will then learn, and start doing work for you (carefully!) and suggesting things, reminding you etc.
-Always watching, and listening and perceiving and then acting. If this is all to much `just simple` will run just the recipesd (no voice or other enhancements)
+Always watching, and listening and perceiving and then acting. If this is all to much `just run-simple` will run just the recipesd (no voice or other enhancements)
 
 
 ## 🎭 Avatar Personality System
@@ -231,6 +231,7 @@ For the hotkey functionality (`Cmd+Shift+G`) to work, you may need to grant perm
 
 ```bash
 just run              # Run the application
+just run-simple       # Run the application without voice or avatar features (just recipes)
 just train-classifier # run the classifier (won't usually need to)
 just status           # to check what is running
 just logs             # to follow along with background things going on
@@ -511,4 +512,3 @@ The system uses a background thread for transcription:
 - **Sequential Processing**: Each audio chunk is processed in order
 - **Reliable Wake Word Detection**: The system processes each chunk fully before moving to the next
 - **Focused Attention**: Once activated, the system captures the entire conversation without interruption
-

--- a/observers/recipe-chrome-history.yaml
+++ b/observers/recipe-chrome-history.yaml
@@ -1,0 +1,45 @@
+version: 1.0.0
+title: Google Chrome History Observer
+author:
+  contact: aarong@squareup.com
+description: Use recent browser history to update a summary of browsing patterns without interrupting the browser session.
+instructions: |
+  1. Copy the locked Chrome History database file to a temporary location.
+  2. Query the copy with sqlite3 to retrieve recent browser history.
+  3. Optionally post-process or filter the results as needed.
+extensions:
+- type: builtin
+  name: developer
+  display_name: Developer
+  timeout: 300
+  bundled: true
+
+prompt: |
+  CURRENT DATE: $(date)
+  
+  **Task: Export and review recent Chrome browsing history, without interrupting browser sessions.**
+  
+  **STEP 1: COPY HISTORY DATABASE**
+  Copy the Chrome History file to a safe, queryable location:
+  - Source: ~/Library/Application Support/Google/Chrome/Default/History
+  - Destination: /tmp/History
+  - Command:
+    cp ~/Library/Application\ Support/Google/Chrome/Default/History /tmp/History
+  
+  **STEP 2: QUERY DATABASE WITH SQLITE3**
+  Query the copied database for recent visits:
+  
+    sqlite3 /tmp/History 'SELECT url, title, last_visit_time FROM urls ORDER BY last_visit_time DESC LIMIT 10;'
+  
+  - `url`: Web address visited
+  - `title`: Page title
+  - `last_visit_time`: Last visit timestamp (WebKit/Chrome format; optional conversion if desired)
+  
+  **STEP 3: OUTPUT AND OPTIONAL PROCESSING**
+  - Display browsing records in a readable format.
+  - Adjust the number of records returned by changing the LIMIT or adding WHERE clauses (e.g., filter by domain or date).
+  - You may refer to the current `~/.local/share/goose-perception/CHROME_HISTORY.md` to understand the user's previous browsing patterns.
+  
+  **OUTPUT:**
+  An updated CHROME_HISTORY.md file summarizing the user's recent browsing patterns. Include: URLs, titles, and readable timestamps
+  saved to ~/.local/share/goose-perception/CHROME_HISTORY.md

--- a/observers/run-observations.sh
+++ b/observers/run-observations.sh
@@ -264,6 +264,7 @@ run_scheduled_recipes() {
   run_recipe_if_needed "recipe-projects.yaml" "morning" "PROJECTS.md" "weekday-only"
   run_recipe_if_needed "recipe-work-personal.yaml" "evening" ".work-personal"
   run_recipe_if_needed "recipe-interactions.yaml" "hourly" "INTERACTIONS.md"
+  run_recipe_if_needed "recipe-chrome-history.yaml" "4h" "CHROME_HISTORY.md" "weekday-only"
   run_recipe_if_needed "recipe-important-attention-message.yaml" "hourly" ".important-messages" "weekday-only"
   run_recipe_if_needed "recipe-interests.yaml" "daily" "INTERESTS.md"
   run_recipe_if_needed "recipe-morning-attention.yaml" "morning" ".morning-attention" "weekday-only"


### PR DESCRIPTION
This pull request introduces a new observer for tracking Chrome browsing history. 


### New Observer Addition:

* [`observers/recipe-chrome-history.yaml`](diffhunk://#diff-0e688c16320a2742fc78ce621f52fef0ca030a08f638958d9c3231fdcb20cd32R1-R45): Added a new observer configuration for extracting and summarizing recent Chrome browsing history. This includes detailed instructions for copying, querying, and processing the browser history database.

### Observation Scheduling Update:

* [`observers/run-observations.sh`](diffhunk://#diff-996f9d98ca59b733a24efae119408aa92bfb5368a4da391f09e937d9dafa215fR267): Updated the scheduling script to include the new Chrome history observer, which runs every 4 hours on weekdays.

### Other changes – Readme updates

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29): Clarified the usage of the `just run-simple` command for running the application without voice or avatar features. This change improves user understanding of the simplified mode. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R234)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L514): Removed an unnecessary blank line in the transcription section for better formatting.
